### PR TITLE
[REF] webhook: Add not implemented exception

### DIFF
--- a/webhook/models/webhook.py
+++ b/webhook/models/webhook.py
@@ -132,4 +132,13 @@ class Webhook(models.TransientModel):
             raise exceptions.ValidationError(_(
                 'att "%s" not found' % self.env.method_event_name))
         webhook_method = getattr(self, self.env.method_event_name)
-        return webhook_method()
+        res_webhook_method = webhook_method()
+        # TODO: Why return a list and not the value returned
+        res_webhook_method2 = isinstance(res_webhook_method, list) \
+            and len(res_webhook_method) == 1 and \
+            res_webhook_method[0] or res_webhook_method
+        if res_webhook_method2 is NotImplemented:
+            raise exceptions.ValidationError(_(
+                'Not implemented method "%s" yet' % (
+                    self.env.method_event_name)))
+        return res_webhook_method

--- a/webhook_github/models/webhook.py
+++ b/webhook_github/models/webhook.py
@@ -10,8 +10,7 @@
 #                moylop260@vauxoo.com
 ############################################################################
 
-from pprint import pprint
-import sys
+# from pprint import pprint
 
 from openerp import api, models
 
@@ -38,6 +37,7 @@ class Webhook(models.Model):
     @api.one
     def run_webhook_github_pull_request(self):
         """
+        Implementation example:
         sys.stdout.write("I'm here: run_webhook_github_pull_request\n")
         # pprint(self.env.request.jsonrequest)
         sys.stdout.write("PR change in: %s/%s/pull/%s\n" % (
@@ -46,11 +46,12 @@ class Webhook(models.Model):
             self.env.request.jsonrequest['pull_request']['number']
         ))
         """
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_push(self):
         """
+        Implementation example:
         sys.stdout.write("I'm here: run_webhook_github_push\n")
         pprint(self.env.request.jsonrequest)
         sys.stdout.write("Push change in: %s/%s\n" % (
@@ -63,83 +64,81 @@ class Webhook(models.Model):
             self.env.request.jsonrequest['ref'] + "\n")
         sys.stdout.write(
             "self.env.request.jsonrequest['base_ref']")
-        sys.stdout.write(
-            self.env.request.jsonrequest['base_ref'] + "\n")
         """
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_commit_comment(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_create(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_delete(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_deployment(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_deployment_status(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_fork(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_gollum(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_issue_comment(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_issues(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_member(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_membership(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_page_build(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_public(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_pull_request_review_comment(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_repository(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_release(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_status(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_team_add(self):
-        return True
+        return NotImplemented
 
     @api.one
     def run_webhook_github_watch(self):
-        return True
+        return NotImplemented


### PR DESCRIPTION
I created a new module to override only method `run_webhook_github_push`

``` python
class Webhook(models.Model):
    _inherit = 'webhook'

    @api.one
    def run_webhook_github_push(self):
        return_res = super(Webhook, self).run_webhook_github_push()
        print "I'm here: runbot run_webhook_github_push"
        return return_res
```

But I don't override other ones.

Then I trigger the event `push` and we can see in terminal
`I'm here: runbot run_webhook_github_push`

Then I trigger the event `status` and we can see in terminal
`ValidationError: ('ValidateError', u'Not implemented method "run_webhook_github_status" yet')`

![captura de pantalla 2015-06-25 a las 10 42 41 p m](https://cloud.githubusercontent.com/assets/6644187/8370322/bad4e822-1b8b-11e5-8fb2-e22e9bdf69a6.png)
