### PR TITLE
[REF] webhook: Add external dependencies to ipaddress python package and add ping event

### DIFF
--- a/webhook/README.md
+++ b/webhook/README.md
@@ -72,3 +72,10 @@ class Webhook(models.Model):
             self.env.request.jsonrequest['repository']['name']
         ))
 ```
+
+External Dependecies
+---------------
+Install python package ipaddress
+You can use pip to install
+`pip install ipaddress`
+

--- a/webhook/__openerp__.py
+++ b/webhook/__openerp__.py
@@ -19,7 +19,7 @@
         'web',
     ],
     'external_dependencies': {
-        'python' : ['ipaddress'],
+        'python': ['ipaddress'],
     },
     'data': [
     ],

--- a/webhook/__openerp__.py
+++ b/webhook/__openerp__.py
@@ -18,6 +18,9 @@
     'depends': [
         'web',
     ],
+    'external_dependencies': {
+        'python' : ['ipaddress'],
+    },
     'data': [
     ],
     'qweb': [

--- a/webhook_github/models/webhook.py
+++ b/webhook_github/models/webhook.py
@@ -35,6 +35,10 @@ class Webhook(models.Model):
                     'X-Github-Event')
 
     @api.one
+    def run_webhook_github_ping(self):
+        return True
+
+    @api.one
     def run_webhook_github_pull_request(self):
         """
         Implementation example:


### PR DESCRIPTION
FYI added with `return True` and not `return NotImplemented` because github send a ping event to configurate a new webhook server and this need return True.

``` python
def run_webhook_github_ping(self):
        return True
```
