### PR TITLE
[REF] .travis: Excluding server_env_base_external_referentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   matrix:
   - LINT_CHECK="1"
   # - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="vauxoo/odoo"
+  - TESTS="1" ODOO_REPO="vauxoo/odoo" EXCLUDE="server_env_base_external_referentials"
   # - TESTS="1" ODOO_REPO="OCA/OCB"
   # - UNIT_TEST="1" 
 


### PR DESCRIPTION
- Module MQT/Vauxoo don't support install: False yet
