### PR TITLE
[FIX] Dependency renaming

### DIFF
--- a/users_ldap_groups/__openerp__.py
+++ b/users_ldap_groups/__openerp__.py
@@ -35,6 +35,6 @@ Adds user accounts to groups based on rules defined by the administrator.
     ],
     "installable": True,
     "external_dependencies": {
-        'python': ['ldap'],
+        'python': ['python-ldap'],
     },
 }

--- a/users_ldap_populate/__openerp__.py
+++ b/users_ldap_populate/__openerp__.py
@@ -42,7 +42,7 @@ object you want to query.
         'auth_ldap',
     ],
     'external_dependencies': {
-        'python': ['ldap'],
+        'python': ['python-ldap'],
     },
     "data": [
         'view/users_ldap.xml',


### PR DESCRIPTION
The dependency to `ldap` python package needs to be updated to `python-ldap` because its name has changed in pypi. This needs to be done so that their requirements are installed correctly.
