### PR TITLE
[8.0][instance_introspection] Get the json with the modules info 

### DIFF
--- a/instance_introspection/views/instance_view.xml
+++ b/instance_introspection/views/instance_view.xml
@@ -10,6 +10,7 @@
 
         <menuitem id="menu_action_open_ii"
             parent="base.menu_custom"
+            sequence='0'
             action="action_open_ii" name="Instance Introspection"/>
      </data>
 </openerp>


### PR DESCRIPTION
Now you can download the modules info on a json object to ease the verify the info from an external script with a request to the instance.
Moved the menu on the top of technical menus
