### PR TITLE
[FIX] Body empty when doesn't match pattern

### DIFF
--- a/mail_attach_image/models/ir_mail_server.py
+++ b/mail_attach_image/models/ir_mail_server.py
@@ -34,6 +34,7 @@ class IrMailServer(models.Model):
         while True:
             match = pattern.search(body, pos)
             if not match:
+                new_body = body
                 break
             start = match.start()
             end = match.end()


### PR DESCRIPTION
If the template doesn't have an image base64 the pattern `'"data:image/png;base64,[^"]*"'` does not match with body and returns an empty new body.
