### PR TITLE
[FIX] mail_attach_image: Replace '%0A' to \n'

### DIFF
--- a/mail_attach_image/models/ir_mail_server.py
+++ b/mail_attach_image/models/ir_mail_server.py
@@ -45,6 +45,7 @@ class IrMailServer(models.Model):
 
             fname = ftemplate % fcounter
             fcounter += 1
+            data = data.replace('%0A', '\n')
             custom_attachments.append((fname, base64.b64decode(data)))
 
             new_body += '"cid:%s"' % fname


### PR DESCRIPTION
The base64 encodestring use newline \n but odoo use a execute
lxml.html.tostring
here https://github.com/odoo/odoo/blob/fe15829c1664c00bc64874af4f504eaffbe1c12f/addons/email_template/email_template.py#L162

Then if you use:

`python -c "import lxml.html;myhtml = lxml.html.fromstring('<html><img src="data:image/png;base64,\n"/></html>');lxml.html.tostring(myhtml, pretty_print=False, method='html')"`

You will see a ugly character '%0A'

Fix https://github.com/Vauxoo/server-tools/issues/61
