### PR TITLE
[ADD] company_country

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - VERSION="9.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
   - TRANSIFEX_USER='transbot@odoo-community.org'
   - secure: Z06mZCN+Hm3myqHSOZpOOk1pd4oq1epAWZv6m9OX2bTNHbhyOVOGK6JWWsnDm/3DUCN1ZeLtSGOl9bvQfMa8ahQHA80MkLL16YlTvQV59Lh+L2gAYmxX+ogJCJgeQSVAXlGLscgkADCu/HzDlmatrDeROMtULn5i23j2qcyUNyM=
+  - COUNTRY="MX"
 
   matrix:
   - LINT_CHECK="1"

--- a/company_country/README.rst
+++ b/company_country/README.rst
@@ -1,0 +1,74 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===============
+company_country
+===============
+
+This module allow set a country to main company in order to use the hook of 
+account that install l10n_** based on country of main company.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Add as depends from your main module.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Set the environment variable COUNTRY using 2 letter of ISO 3166 codes.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Just start server installing your main module.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/{repo_id}/{branch}
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/{project_repo}/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Vauxoo
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Moisés López <moylop260@vauxoo.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/company_country/__init__.py
+++ b/company_country/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Vauxoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import models

--- a/company_country/__openerp__.py
+++ b/company_country/__openerp__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# © 2016  Vauxoo (<http://www.vauxoo.com/>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Country Company",
+    "summary": "Set country to main company",
+    "version": "8.0.1.0.0",
+    "category": "base",
+    "website": "https://odoo-community.org/",
+    "author": "Vauxoo, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": [],
+    "data": ['data/res_config.xml'],
+    "sequence": 1,
+    "auto_install": False,
+    "installable": True,
+}

--- a/company_country/data/res_config.xml
+++ b/company_country/data/res_config.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo>
+    <data noupdate="1">
+        <function name="load_country_company" model="country.company.config.settings"/>
+    </data>
+</odoo>

--- a/company_country/models/__init__.py
+++ b/company_country/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Vauxoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import res_config

--- a/company_country/models/res_config.py
+++ b/company_country/models/res_config.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Vauxoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import os
+
+from openerp import api, exceptions, models
+
+
+class CountryCompanyConfigSettings(models.TransientModel):
+    _name = 'country.company.config.settings'
+
+    @api.model
+    def load_country_company(self, country_code=None):
+        if not country_code:
+            country_code = os.environ.get('COUNTRY')
+        if not country_code:
+            raise exceptions.ValidationError(
+                'Error COUNTRY environment variable with country code '
+                'not defined')
+        country = self.env['res.country'].search([
+            ('code', 'ilike', country_code)], limit=1)
+        if not country:
+            raise exceptions.ValidationError(
+                'Country code %s not found. Use ISO 3166 codes 2 letters')
+        self.env.ref('base.main_company').write({'country_id': country.id})


### PR DESCRIPTION
company_country
===============

This module allow set a country to main company in order to use the hook of 
account that install l10n_** based on country of main company.

Installation
============

To install this module, you need to:

#. Add as depends from your main module.

Configuration
=============

To configure this module, you need to:

#. Set the environment variable COUNTRY using 2 letter of ISO 3166 codes.

Usage
=====

To use this module, you need to:

#. Just start server installing your main module.