### PR TITLE
[FIX] password_security: Avoid ERROR 500 on failing password.

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -156,3 +156,21 @@ class ResUsers(models.Model):
                 'password_crypt': encrypted,
             })],
         })
+
+    # Dirty fix because this was failing when any theme was installed
+    # I think this should be a fix in the core.
+
+    @api.multi
+    def _is_system(self):
+        if not self:
+            return False
+        return super(ResUsers, self)._is_system()
+
+    @api.multi
+    def _is_superuser(self):
+        if not self:
+            return False
+        return super(ResUsers, self)._is_superuser()
+
+    # ------------ End of dirty fix ----------------- #
+


### PR DESCRIPTION
Summary
-------------

When any theme was installed toghether to website this methods expected a singleton but they received in one request "res.users()" because of this I think the ensure_one is failing badly.

- backport from saas-14 d409c85