### PR TITLE
[FIX] odoolint: Fix AccessError for ir.model.data

### DIFF
--- a/odoolint/models/ir_model_data.py
+++ b/odoolint/models/ir_model_data.py
@@ -110,7 +110,7 @@ class IrModelData(models.Model):
     @tools.ormcache('xmlid')
     def xmlid_lookup(self, xmlid):
         res = super(IrModelData, self).xmlid_lookup(xmlid)
-        record = self.browse([res[0]])
+        record = self.sudo().browse([res[0]])
         record._check_data_ref_demo()
         record._check_xml_id_unreachable(xmlid)
         return res


### PR DESCRIPTION
After commit https://github.com/odoo/odoo/commit/6453e4eb23f43b0508bdc6f613e225b0763e9f68
the xml_id access is not allowed for non-sudo