### PR TITLE
[FIX] password_security: allow users creation to erp manager

### DIFF
--- a/password_security/security/res_users_pass_history.xml
+++ b/password_security/security/res_users_pass_history.xml
@@ -6,14 +6,23 @@
 -->
 
 <odoo>
-    
+
     <record id="res_users_pass_history_rule" model="ir.rule">
-        <field name="name">Res Users Pass History Access</field>
+        <field name="name">Res Users Pass History Access User</field>
         <field name="model_id" ref="password_security.model_res_users_pass_history"/>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
-        <field name="domain_force">[
-            ('user_id', '=', user.id)
-        ]</field>
+        <field name="domain_force">[('user_id', '=', user.id)]</field>
+    </record>
+
+    <record id="res_users_pass_history_rule_manager" model="ir.rule">
+        <field name="name">Res Users Pass History Access Manager</field>
+        <field name="model_id" ref="password_security.model_res_users_pass_history"/>
+        <field name="groups" eval="[(4, ref('base.group_erp_manager'))]"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
 </odoo>


### PR DESCRIPTION
Summary
-------------

Previously restriction was denied users creation to users different to root user _(Administrator)_. In order to solve this issue was create a new rule to allow create register in `res.user.pass.history` model to users in group erp manager _(Administration / Access Rights)_

To solve:
https://github.com/Vauxoo/server-tools/issues/100