### PR TITLE
[FIX] It avoids validating the password_history when updating the auth_crypt module.

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -130,8 +130,14 @@ class ResUsers(models.Model):
         :raises: PassError on reused password
         """
         crypt = self._crypt_context()
+        # TODO: Check if this is the correct way to avoid validating the
+        # password_history when updating the auth_crypt module
+        if self._context.get('todo', False):
+            return super(ResUsers, self)._set_password(password)
         for rec_id in self:
             recent_passes = rec_id.company_id.password_history
+            if not recent_passes:
+                continue
             if recent_passes < 0:
                 recent_passes = rec_id.password_history_ids
             else:
@@ -145,7 +151,7 @@ class ResUsers(models.Model):
                     _('Cannot use the most recent %d passwords') %
                     rec_id.company_id.password_history
                 )
-        super(ResUsers, self)._set_password(password)
+        return super(ResUsers, self)._set_password(password)
 
     @api.multi
     def _set_encrypted_password(self, encrypted):

--- a/password_security/tests/test_res_users.py
+++ b/password_security/tests/test_res_users.py
@@ -146,3 +146,15 @@ class TestResUsers(TransactionCase):
         self.assertEqual(
             True, rec_id._validate_pass_reset(),
         )
+
+    def test_set_password_auth_crypt(self):
+        """Users password must be updated during a module update or install"""
+        rec_id = self._new_record()
+        password_new = 'QWE123$%^asd'
+        rec_id.write({'password': password_new})
+        password_new = '123QWE$%^asd'
+        rec_id.write({'password': password_new})
+        self.model_obj.init()
+        self.assertEqual(
+            3, len(rec_id.password_history_ids),
+        )


### PR DESCRIPTION
When attempting to install the project_forecast module, a popup window is displayed with the following message: "Can not use the most recent 30 passwords" this is a message that comes from the password_security module, this occurs because it automatically updates the auth_crypt module And this module has this [init](https://github.com/Vauxoo/odoo/blob/10.0/addons/auth_crypt/models/res_users.py#L29) that updates all the users passwords, but assigning the same password, which produces a repeated password error, this if the password history is different from 0. To avoid this, use the value 'todo' Which was found in context when updating the auth_crypt module.

Tests were performed installing the module and modifying passwords, and the proposed change works