### PR TITLE
[saas-15][mass_editing] Fixed error when you try to set fields in mass.editing form view

### DIFF
--- a/mass_editing/models/mass_object.py
+++ b/mass_editing/models/mass_object.py
@@ -48,6 +48,10 @@ class MassObject(models.Model):
                 model_ids.extend((inherits_model_ids and
                                   inherits_model_ids.ids or []))
         self.model_ids = [(6, 0, model_ids)]
+        res = {'domain': {
+            'field_ids': [('ttype', 'not in', ['reference', 'function']),
+                          ('model_id', 'in', model_ids)]}}
+        return res
 
     @api.multi
     def create_action(self):

--- a/mass_editing/views/mass_editing_view.xml
+++ b/mass_editing/views/mass_editing_view.xml
@@ -44,8 +44,7 @@
                     </div>
                     <notebook colspan="4">
                         <page string="Fields">
-                            <field name="field_ids" colspan="4" nolabel="1"
-                            domain="[('ttype', 'not in', ['reference', 'function']), ('model_id', 'in', model_ids and model_ids[0][2] or [])]"/>
+                            <field name="field_ids" colspan="4" nolabel="1"/>
                         </page>
                         <page string="Advanced" attrs="{'invisible':[('ref_ir_act_window_id','=',False)]}">
                             <group colspan="2" col="2">


### PR DESCRIPTION
The domain used to filter fields is now set from onchange method, to avoid errors when you try to set the fields in mass.editing object