### PR TITLE
[FIX] country_company: Don't fail on COUNTRY=""

### DIFF
--- a/company_country/models/res_config.py
+++ b/company_country/models/res_config.py
@@ -14,6 +14,8 @@ class CountryCompanyConfigSettings(models.TransientModel):
     def load_country_company(self, country_code=None):
         if not country_code:
             country_code = os.environ.get('COUNTRY')
+        if country_code == "":
+            return
         if not country_code:
             raise ValidationError(
                 _('Error COUNTRY environment variable with country code'


### PR DESCRIPTION
There are cases when we need to set the COUNTRY variable to an empty
value, but this module is raising an exception.