### PR TITLE
[FIX] password_security: allow users creation to erp manager

### DIFF
--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -7,11 +7,11 @@ import operator
 from odoo import http
 from odoo.http import request
 try:
-    from odoo.addons.website.controllers.main import AuthSignupHome as SignupHome
+    from odoo.addons.website.controllers.main import AuthSignupHome
 except ImportError:
-    from odoo.addons.auth_signup.controllers.main import AuthSignupHome as SignupHome
-from odoo.addons.web.controllers.main import ensure_db, Session
+    from odoo.addons.auth_signup.controllers.main import AuthSignupHome
 
+from odoo.addons.web.controllers.main import ensure_db, Session
 from ..exceptions import PassError
 
 
@@ -27,7 +27,7 @@ class PasswordSecuritySession(Session):
         return super(PasswordSecuritySession, self).change_password(fields)
 
 
-class PasswordSecurityHome(SignupHome):
+class PasswordSecurityHome(AuthSignupHome):
 
     def do_signup(self, qcontext):
         password = qcontext.get('password')

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -6,7 +6,7 @@ import re
 
 from datetime import datetime, timedelta
 
-from odoo import api, fields, models, SUPERUSER_ID, _
+from odoo import api, fields, models, _
 
 from ..exceptions import PassError
 
@@ -171,5 +171,4 @@ class ResUsers(models.Model):
         if not self:
             return False
         return super(ResUsers, self)._is_superuser()
-
-    ############ End of dirty fix ###############
+    # End of dirty fix

--- a/password_security/security/res_users_pass_history.xml
+++ b/password_security/security/res_users_pass_history.xml
@@ -6,14 +6,23 @@
 -->
 
 <odoo>
-    
+
     <record id="res_users_pass_history_rule" model="ir.rule">
-        <field name="name">Res Users Pass History Access</field>
+        <field name="name">Res Users Pass History Access User</field>
         <field name="model_id" ref="password_security.model_res_users_pass_history"/>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
-        <field name="domain_force">[
-            ('user_id', '=', user.id)
-        ]</field>
+        <field name="domain_force">[('user_id', '=', user.id)]</field>
+    </record>
+
+    <record id="res_users_pass_history_rule_manager" model="ir.rule">
+        <field name="name">Res Users Pass History Access Manager</field>
+        <field name="model_id" ref="password_security.model_res_users_pass_history"/>
+        <field name="groups" eval="[(4, ref('base.group_erp_manager'))]"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
 </odoo>


### PR DESCRIPTION
Summary
-------------

Previously restriction was denied users creation to users
different to root user (Administrator). In order to solve
this issue was create a new rule to allow create register
in res.user.pass.history model to users in group erp manager
(Administration / Access Rights)

To solve:
https://github.com/Vauxoo/server-tools/issues/100