### PR TITLE
[FIX] country_company: Don't fail on COUNTRY=""

### DIFF
--- a/company_country/__manifest__.py
+++ b/company_country/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Country Company",
     "summary": "Set country to main company",
-    "version": "10.0.1.0.0",
+    "version": "11.0.1.0.0",
     "category": "base",
     "website": "https://odoo-community.org/",
     "author": "Vauxoo, Odoo Community Association (OCA)",

--- a/company_country/models/res_config.py
+++ b/company_country/models/res_config.py
@@ -14,6 +14,9 @@ class CountryCompanyConfigSettings(models.TransientModel):
     def load_country_company(self, country_code=None):
         if not country_code:
             country_code = os.environ.get('COUNTRY')
+        if country_code == "":
+            self.env.ref('base.main_company').write({'country_id': None})
+            return
         if not country_code:
             raise ValidationError(
                 _('Error COUNTRY environment variable with country code'


### PR DESCRIPTION
There are cases when we need to set the COUNTRY variable to an empty
value, but this module is raising an exception.

This is a cherry-pick of the commit merged on #115 for `saas-15`.