### PR TITLE
[FIX] password_security: allow users creation to erp manager

### DIFF
--- a/password_security/__manifest__.py
+++ b/password_security/__manifest__.py
@@ -5,7 +5,7 @@
 
     'name': 'Password Security',
     "summary": "Allow admin to set password security requirements.",
-    'version': '10.0.1.0.1',
+    'version': '11.0.0.0.1',
     'author': "LasLabs, Odoo Community Association (OCA)",
     'category': 'Base',
     'depends': [

--- a/password_security/security/res_users_pass_history.xml
+++ b/password_security/security/res_users_pass_history.xml
@@ -6,14 +6,23 @@
 -->
 
 <odoo>
-    
+
     <record id="res_users_pass_history_rule" model="ir.rule">
-        <field name="name">Res Users Pass History Access</field>
+        <field name="name">Res Users Pass History Access User</field>
         <field name="model_id" ref="password_security.model_res_users_pass_history"/>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
-        <field name="domain_force">[
-            ('user_id', '=', user.id)
-        ]</field>
+        <field name="domain_force">[('user_id', '=', user.id)]</field>
+    </record>
+
+    <record id="res_users_pass_history_rule_manager" model="ir.rule">
+        <field name="name">Res Users Pass History Access Manager</field>
+        <field name="model_id" ref="password_security.model_res_users_pass_history"/>
+        <field name="groups" eval="[(4, ref('base.group_erp_manager'))]"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
 </odoo>

--- a/password_security/tests/test_password_security_home.py
+++ b/password_security/tests/test_password_security_home.py
@@ -47,7 +47,7 @@ class TestPasswordSecurityHome(TransactionCase):
                    'web_auth_reset_password',
                    ]
         with mock.patch.multiple(
-            main.AuthSignupHome, **{m: mock.DEFAULT for m in methods}
+            main.SignupHome, **{m: mock.DEFAULT for m in methods}
         ) as _super:
             mocks = {}
             for method in methods:
@@ -203,7 +203,7 @@ class TestPasswordSecurityHome(TransactionCase):
         """ It should catch PassError and get signup qcontext """
         with self.mock_assets() as assets:
             with mock.patch.object(
-                main.AuthSignupHome, 'get_auth_signup_qcontext',
+                main.SignupHome, 'get_auth_signup_qcontext',
             ) as qcontext:
                 assets['web_auth_signup'].side_effect = MockPassError
                 qcontext.side_effect = EndTestException
@@ -214,7 +214,7 @@ class TestPasswordSecurityHome(TransactionCase):
         """ It should render & return signup form on invalid """
         with self.mock_assets() as assets:
             with mock.patch.object(
-                main.AuthSignupHome, 'get_auth_signup_qcontext', spec=dict
+                main.SignupHome, 'get_auth_signup_qcontext', spec=dict
             ) as qcontext:
                 assets['web_auth_signup'].side_effect = MockPassError
                 res = self.password_security_home.web_auth_signup()
@@ -229,7 +229,7 @@ class TestPasswordSecurityHome(TransactionCase):
         """ It should raise from failed _validate_pass_reset by login """
         with self.mock_assets() as assets:
             with mock.patch.object(
-                main.AuthSignupHome, 'get_auth_signup_qcontext', spec=dict
+                main.SignupHome, 'get_auth_signup_qcontext', spec=dict
             ) as qcontext:
                 qcontext['login'] = 'login'
                 search = assets['request'].env.sudo().search
@@ -244,7 +244,7 @@ class TestPasswordSecurityHome(TransactionCase):
         """ It should raise from failed _validate_pass_reset by email """
         with self.mock_assets() as assets:
             with mock.patch.object(
-                main.AuthSignupHome, 'get_auth_signup_qcontext', spec=dict
+                main.SignupHome, 'get_auth_signup_qcontext', spec=dict
             ) as qcontext:
                 qcontext['login'] = 'login'
                 search = assets['request'].env.sudo().search
@@ -259,7 +259,7 @@ class TestPasswordSecurityHome(TransactionCase):
         """ It should return parent response on no validate errors """
         with self.mock_assets() as assets:
             with mock.patch.object(
-                main.AuthSignupHome, 'get_auth_signup_qcontext', spec=dict
+                main.SignupHome, 'get_auth_signup_qcontext', spec=dict
             ) as qcontext:
                 qcontext['login'] = 'login'
                 assets['request'].httprequest.method = 'POST'


### PR DESCRIPTION
Summary
-------------

Previously restriction was denied users creation to users different to root user (Administrator). In order to solve this issue was create a new rule to allow create register in `res.user.pass.history` model to users in group erp manager _(Administration / Access Rights)_

To solve:
https://github.com/Vauxoo/server-tools/issues/100