### PR TITLE
[REF] requirements.txt: Remove unnecessary packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
-pyldap==2.4.28
-unidecode
+checksumdir
+raven
+pysftp
 acme_tiny
 IPy
-validate_email
-pysftp
-fdb
-sqlalchemy


### PR DESCRIPTION
When modules present in other projectswere removed from this one to
avoid duplications (#140), the requirements.txt was left untouched, even
though some of the packages are no longer required.

This removes those packages, copying the requirements.txt from
OCA/server-tools.