### PR TITLE
[DUMMY] company_country: Use MX country by default

### DIFF
--- a/company_country/models/res_config.py
+++ b/company_country/models/res_config.py
@@ -11,7 +11,7 @@ class CompanyCountryConfigSettings(models.TransientModel):
     _description = 'Company Country Configuration Settings'
 
     @api.model
-    def load_company_country(self, country_code=None):
+    def load_company_country(self, country_code='MX'):
         if not country_code:
             country_code = os.environ.get('COUNTRY')
         if country_code == "":


### PR DESCRIPTION
This is intended to be used under Odoo.sh when the localization is
already installed, because environment variables are not under our
control there.

# Conflicts:
#	company_country/models/res_config.py