### PR TITLE
[FIX] company_country: Don't fail if account is already installed (#1…

### DIFF
--- a/company_country/__manifest__.py
+++ b/company_country/__manifest__.py
@@ -4,9 +4,10 @@
 {
     "name": "Country Company",
     "summary": "Set country to main company",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "category": "base",
     "website": "https://odoo-community.org/",
+    "maintainers": ['moylop260', 'luisg123v'],
     "author": "Vauxoo, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": [],

--- a/company_country/models/res_config.py
+++ b/company_country/models/res_config.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 Vauxoo
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
 import os
 
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
 
 
 class CountryCompanyConfigSettings(models.TransientModel):
@@ -12,10 +15,20 @@ class CountryCompanyConfigSettings(models.TransientModel):
 
     @api.model
     def load_country_company(self, country_code=None):
+        account_installed = self.env['ir.module.module'].search([
+            ('name', '=', 'account'),
+            ('state', '=', 'installed'),
+            ], limit=1)
+        if account_installed:
+            # If the account module is installed, that means changing the
+            # company's country will have no effect, as the account hook was
+            # already run and an l10n module was already been installed
+            _logger.info("account module already installed, skipping")
+            return
         if not country_code:
             country_code = os.environ.get('COUNTRY')
         if country_code == "":
-            self.env.ref('base.main_company').write({'country_id': None})
+            self.env.ref('base.main_company').write({'country_id': False})
             return
         if not country_code:
             l10n_to_install = self.env['ir.module.module'].search([

--- a/company_country/tests/test_company_country.py
+++ b/company_country/tests/test_company_country.py
@@ -1,0 +1,52 @@
+# Copyright 2016 Vauxoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import os
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+
+class TestCompanyCountry(TransactionCase):
+
+    def setUp(self):
+        super(TestCompanyCountry, self).setUp()
+        self.wizard = self.env['company.country.config.settings']
+        self.us_country = self.env.ref('base.us')
+        self.mx_country = self.env.ref('base.mx')
+        self.main_company = self.env.ref('base.main_company')
+        self.module_account = self.env.ref('base.module_account')
+        self.main_company.write({'country_id': self.us_country.id})
+        self.module_account.write({'state': 'uninstalled'})
+        self.env_country = os.environ.get('COUNTRY')
+
+    def tearDown(self):
+        super(TestCompanyCountry, self).tearDown()
+        os.environ['COUNTRY'] = self.env_country
+
+    def test01_company_country_changed(self):
+        self.wizard.load_company_country(country_code='MX')
+        self.assertEqual(self.main_company.country_id, self.mx_country)
+
+    def test02_country_environment_values(self):
+        # Country Code unknown, should raise
+        with self.assertRaises(ValidationError):
+            self.wizard.load_company_country(country_code='BAD')
+
+        # COUNTRY as empty string, should unset Country of main company
+        os.environ['COUNTRY'] = ""
+        self.wizard.load_company_country()
+        self.assertEqual(self.main_company.country_id.id, False)
+
+        # COUNTRY environment variable not set, should raise
+        with self.assertRaises(ValidationError):
+            l10n_to_install = self.env['ir.module.module'].search([
+                ('state', '=', 'to install'),
+                ('name', '=like', 'l10n_%')])
+            l10n_to_install.write({'state': 'uninstalled'})
+            del os.environ['COUNTRY']
+            self.wizard.load_company_country()
+
+        # Account is already installed, shouldn't raise
+        self.module_account.write({'state': 'installed'})
+        self.wizard.load_company_country()


### PR DESCRIPTION
…786)

When `company_country` is installed, it performs the following:
- Look for the `COUNTRY` environment variable
- If not found, look for a `l10n_*` module that is about to be installed
- If not found, raise an exception

However, If the account module is installed, it shouldn't fail even if
the environment variable is not defined, because changing the
company's country will have no effect anyway, as the account hook was
already run and an `l10n` module was already been installed.

This commit fixes the above by skipping the process if the `account`
module is installed, and print an informative message to the log.

Co-authored-by: Moises Lopez - https://www.vauxoo.com/ <moylop260@vauxoo.com>

This is a manual backport from 12.0 of:
- https://github.com/OCA/server-tools/commit/e84608c3cb7566ce0fe484d6bbd0257a8f96d64f