### PR TITLE
[FIX] auth_totp: Freeze pyotp python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ unidecode
 acme_tiny
 IPy
 email_validator
-pyotp
+pyotp==2.2.7
 pysftp
 fdb
 sqlalchemy


### PR DESCRIPTION
The actual version is not compatible with python 2.7 