### PR TITLE
[FIX] numpy library "Segmentation fault (core dumped)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ xlwt
 pysftp
 # version 1.2.0 deprecates the API module_analysis uses
 pygount<1.2.0
+numpy==1.19.2


### PR DESCRIPTION
More info about:
 - https://github.com/Vauxoo/maintainer-quality-tools/pull/315

And here:
 - https://github.com/numpy/numpy/issues/17674

So, using a pinned numpy version where the error is not raised we can bypassing this error.
The unique project used for all our customer is server-tools

Revert this change after it is fixed.