### PR TITLE
[FIX] server_environment: update package configparser that support py2 and py3

### DIFF
--- a/server_environment/serv_config.py
+++ b/server_environment/serv_config.py
@@ -20,7 +20,7 @@
 ##############################################################################
 
 import os
-import ConfigParser
+import configparser
 from lxml import etree
 from itertools import chain
 
@@ -91,7 +91,7 @@ def _load_config():
     else:
         conf_files = _listconf(running_env)
 
-    config_p = ConfigParser.SafeConfigParser()
+    config_p = configparser.SafeConfigParser()
     # options are case-sensitive
     config_p.optionxform = str
     try:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In projects v11.0 that use `server_environment` module, an error is generated:

```
File "/home/odoo/server-tools/server_environment/serv_config.py", line 23, in <module>
import ConfigParser
ImportError: No module named 'ConfigParser'
```

`ConfigParser` package has updated to `configparser` and support py2 and py3.

More information:
https://pypi.org/project/configparser/

Current behavior before PR:
In projects v11.0 that use `server_environment`module with error to try run odoo.

Desired behavior after PR is merged:
In projects v11.0 that use `server_environment`module without errors related with `configparser`.

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
