### PR TITLE
[FIX] Freeze Unicode python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
   pstats_print2list
   python-ldap
-  unidecode
+  unidecode==1.2.0
   validate_email
   pysftp
   acme_tiny


### PR DESCRIPTION

Since the new version is not compatible with py2.7 which is the python used in this Odoo version.