### PR TITLE
[REF] requirements.txt: pin email-validator to 1.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ python-ldap
 unidecode==1.2.0
 acme_tiny
 IPy
-email_validator
+email_validator==1.1.3
 pyotp==2.2.7
 pysftp
 fdb


### PR DESCRIPTION
Because is the last version know to work under Python 2.7